### PR TITLE
Bump core2 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 thiserror-impl = { version = "=1.0.23", path = "impl" }
-core2 = { version = "0.3.0-alpha.1", default-features = false }
+core2 = { version = "0.3.3", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
This just bumps up the `core2` version to `0.3.3` so new `Error` impls can be used. To be fair, I don't know how to handle versioning, as its currently `1.0.23` because it based on upstream's `1.0.23` so bumping up PATCH number wouldn't have much sense.