### PR TITLE
Use modified version of -impl subcrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["rust-patterns"]
 readme = "README.md"
 
 [dependencies]
-thiserror-impl = { version = "=1.0.30", path = "impl" }
+thiserror_core2-impl = { version = "=1.0.30", path = "impl" }
 core2 = { version = "0.4", default-features = false }
 
 [dev-dependencies]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "thiserror-impl"
+name = "thiserror_core2-impl"
 version = "1.0.30"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"
 rust-version = "1.31"
 license = "MIT OR Apache-2.0"
-description = "Implementation detail of the `thiserror` crate"
-repository = "https://github.com/dtolnay/thiserror"
+description = "Implementation detail of the `thiserror_core2` crate"
+repository = "https://github.com/bbqsrc/thiserror-core2"
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@
 mod aserror;
 mod display;
 
-pub use thiserror_impl::*;
+pub use thiserror_core2_impl::*;
 
 // Not public API.
 #[doc(hidden)]


### PR DESCRIPTION
Hey,

it seems that by mistake `thiserror_core2` crate depends on mainline version of `impl` (that is `thiserror-impl` crate), instead of modified version which is in this repository. Because of that, it does not compile when using version from `crates.io`

MRE
```rust
use thiserror_core2::Error;

#[derive(Error, Debug)]
enum Foo {
    #[error("{0}")]
    Bar(usize)
}
```