### PR TITLE
Fix no_std builds on nightly via no_std attribute and explicit imports

### DIFF
--- a/src/aserror.rs
+++ b/src/aserror.rs
@@ -1,5 +1,7 @@
-use core2::error::Error;
+use core::marker::Send;
+use core::marker::Sync;
 use core::panic::UnwindSafe;
+use core2::error::Error;
 
 pub trait AsDynError<'a> {
     fn as_dyn_error(&self) -> &(dyn Error + 'a);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@
 //!   }
 //!   ```
 
+#![no_std]
 #![allow(
     // Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7421
     clippy::doc_markdown,


### PR DESCRIPTION
tested on rustc 1.62.0-nightly